### PR TITLE
feat(ci-version): don't use the git tag as version

### DIFF
--- a/.github/workflows/action.flutter.build.yaml
+++ b/.github/workflows/action.flutter.build.yaml
@@ -46,11 +46,10 @@ jobs:
           BUILD_NUMBER=$(date +%s)
           BUILD_NAME=$(git describe --abbrev=0 --tags)
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
-          echo "BUILD_NAME=$BUILD_NAME" >> $GITHUB_ENV
-          echo "This build is tagged as $BUILD_NAME+$BUILD_NUMBER on $GITHUB_REF"
+          echo "This build is tagged as $BUILD_NUMBER on $GITHUB_REF"
       - name: 'Build Android APK'
         if: ${{ inputs.android_output == 'apk' }}
-        run: flutter build apk --build-name="$BUILD_NAME" --build-number="$BUILD_NUMBER" --split-per-abi
+        run: flutter build apk --build-number="$BUILD_NUMBER" --split-per-abi
         env:
           BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
           BUILD_NAME: ${{ env.BUILD_NAME }}
@@ -63,7 +62,7 @@ jobs:
           path: build/app/outputs/apk/release/app-arm64-v8a-release.apk
       - name: 'Build Android App Bundle'
         if: ${{ inputs.android_output == 'aab' }}
-        run: flutter build appbundle --build-name="$BUILD_NAME" --build-number="$BUILD_NUMBER" --dart-define=SENTRY_DSN="$SENTRY_DSN" --dart-define=ENV="$ENV"
+        run: flutter build appbundle --build-number="$BUILD_NUMBER" --dart-define=SENTRY_DSN="$SENTRY_DSN" --dart-define=ENV="$ENV"
         env:
           BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
           BUILD_NAME: ${{ env.BUILD_NAME }}

--- a/.github/workflows/push.tag-beta.yaml
+++ b/.github/workflows/push.tag-beta.yaml
@@ -10,11 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  flutter-test-analyze:
-    uses: ./.github/workflows/action.flutter.analyze-test.yaml
-    with:
-      flutter_version: '3.19.3'
-    secrets: inherit
   flutter-build:
     needs: [ flutter-test-analyze ]
     uses: ./.github/workflows/action.flutter.build.yaml

--- a/.github/workflows/push.tag-prod.yaml
+++ b/.github/workflows/push.tag-prod.yaml
@@ -10,11 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  flutter-test-analyze:
-    uses: ./.github/workflows/action.flutter.analyze-test.yaml
-    with:
-      flutter_version: '3.19.3'
-    secrets: inherit
   flutter-build:
     needs: [ flutter-test-analyze ]
     uses: ./.github/workflows/action.flutter.build.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Mobile app to get the closing and opening schedules of the Chaban D
 
 publish_to: 'none'
 
-version: 0.0.0-dev
+version: 2.6.1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Now the ´version:´ field into the pubspec.yaml will be use and tests won't be played for a new beta or production release