### PR TITLE
fix(multi-boat-events): Fix the multi boat event separator.

### DIFF
--- a/lib/const.dart
+++ b/lib/const.dart
@@ -151,4 +151,5 @@ class Const {
   static const String sentryDSNEnvKey = 'SENTRY_DSN';
   static const String envKey = 'ENV';
   static const String defaultEnv = 'dev';
+  static const String multiBoatsEventSeparator = r' - ';
 }

--- a/lib/models/boat_forecast.dart
+++ b/lib/models/boat_forecast.dart
@@ -1,3 +1,4 @@
+import 'package:chabo_app/const.dart';
 import 'package:chabo_app/cubits/time_format_cubit.dart';
 import 'package:chabo_app/extensions/boats_extension.dart';
 import 'package:chabo_app/extensions/color_scheme_extension.dart';
@@ -61,7 +62,8 @@ class BoatForecast extends AbstractForecast {
     List<Boat> boats = [];
     bool isLeaving = false;
     final rawBoatName = json['fields']['bateau'] as String;
-    final boatNames = rawBoatName.split(RegExp(r'/'));
+    // For multi boat events, extract all the boat name
+    final boatNames = rawBoatName.split(RegExp(Const.multiBoatsEventSeparator));
     for (final boatName in boatNames) {
       final trimmedBoatName = boatName.trim();
       isLeaving = allBoatNames.contains(trimmedBoatName);


### PR DESCRIPTION
For the 2026 season, Bordeaux Metropole decided that the separator to list multiple boats will not be ` / ` anymore but ` - `.

Adding this string as a Const to easier changes in the future