### PR TITLE
fix(v3): Fix the v3 crash start

### DIFF
--- a/lib/widgets/ad_banner_widget.dart
+++ b/lib/widgets/ad_banner_widget.dart
@@ -16,37 +16,47 @@ class AdBannerWidget extends StatefulWidget {
 }
 
 class _AdBannerWidgetState extends State<AdBannerWidget> {
-  late NativeAd _bannerAd;
-  Ad? _ad;
+  BannerAd? _ad;
+  bool _isAdLoaded = false;
 
-  void _createBannerAd() {
-    _bannerAd = NativeAd(
+  void _loadAd(AdSize size) async {
+    _ad = _buildAdBanner(size);
+    await _ad?.load();
+    setState(() {
+      _isAdLoaded = true;
+    });
+  }
+
+  BannerAd _buildAdBanner(AdSize size) {
+    return BannerAd(
       adUnitId: AdHelper.nativeAdUnitId(),
-      factoryId: 'listTile',
+      size: size,
       request: const AdRequest(),
-      listener: NativeAdListener(
+      listener: BannerAdListener(
         onAdLoaded: (ad) {
           setState(() {
-            _ad = ad;
+            _isAdLoaded = true;
           });
         },
         onAdFailedToLoad: (ad, error) {
           developer.log(
-            'Enable to load the ad : ${error.message}',
+            'Unable to load the ad: ${error.message}',
             level: 50,
-            name: 'banner-widget.on.adLoaded',
+            name: 'banner-widget.onAdFailedToLoad',
           );
           _ad?.dispose();
+          setState(() {
+            _isAdLoaded = false;
+          });
         },
       ),
     );
-    _bannerAd.load();
   }
 
   @override
   void initState() {
-    _createBannerAd();
     super.initState();
+    _loadAd(AdSize.banner); // Default size, will be updated in FutureBuilder
   }
 
   @override
@@ -57,38 +67,68 @@ class _AdBannerWidgetState extends State<AdBannerWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final screenWidth = MediaQuery.of(context).size.width;
+    return FutureBuilder<AnchoredAdaptiveBannerAdSize?>(
+      future: AdSize.getLargeAnchoredAdaptiveBannerAdSize(
+        MediaQuery.sizeOf(context).width.truncate(),
+      ),
+      builder:
+          (
+            BuildContext context,
+            AsyncSnapshot<AnchoredAdaptiveBannerAdSize?> snapshot,
+          ) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
 
-    return _ad != null
-        ? Card(
-            child: Container(
-              key: const ValueKey('adContent'),
-              constraints: BoxConstraints(
-                maxHeight: 55,
-                maxWidth: DeviceHelper.isPortrait(context)
-                    ? screenWidth
-                    //ignore: avoid-nested-conditional-expressions
-                    : !DeviceHelper.isMobile(context)
-                    ? screenWidth / 1.55
-                    : screenWidth / 2.13,
-              ),
-              alignment: Alignment.center,
-              child: AnimatedSize(
-                curve: Curves.ease,
-                duration: const Duration(seconds: 1),
-                child: AnimatedSwitcher(
-                  duration: const Duration(seconds: 1),
-                  reverseDuration: const Duration(
-                    milliseconds: CustomProperties.animationDurationMs,
-                  ),
-                  transitionBuilder: (child, animation) {
-                    return FadeTransition(opacity: animation, child: child);
-                  },
-                  child: AdWidget(ad: _bannerAd),
-                ),
-              ),
-            ),
-          )
-        : const SizedBox.shrink();
+            if (snapshot.connectionState == ConnectionState.none ||
+                snapshot.data == null) {
+              return const Text('Error loading ad size');
+            }
+
+            final size = snapshot.data!;
+            if (!_isAdLoaded) {
+              _loadAd(size);
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            final screenWidth = MediaQuery.of(context).size.width;
+
+            return _ad != null
+                ? Card(
+                    key: widget.key,
+                    child: Container(
+                      constraints: BoxConstraints(
+                        maxHeight: 55,
+                        maxWidth: DeviceHelper.isPortrait(context)
+                            ? screenWidth
+                            //ignore: avoid-nested-conditional-expressions
+                            : !DeviceHelper.isMobile(context)
+                            ? screenWidth / 1.55
+                            : screenWidth / 2.13,
+                      ),
+                      alignment: Alignment.center,
+                      child: AnimatedSize(
+                        curve: Curves.ease,
+                        duration: const Duration(seconds: 1),
+                        child: AnimatedSwitcher(
+                          duration: const Duration(seconds: 1),
+                          reverseDuration: const Duration(
+                            milliseconds: CustomProperties.animationDurationMs,
+                          ),
+                          transitionBuilder: (child, animation) {
+                            return FadeTransition(
+                              opacity: animation,
+                              child: child,
+                            );
+                          },
+                          child: Text('data'),
+                          //child: AdWidget(ad: _ad!),
+                        ),
+                      ),
+                    ),
+                  )
+                : const SizedBox.shrink();
+          },
+    );
   }
 }

--- a/lib/widgets/forecast/forecast_list_widget.dart
+++ b/lib/widgets/forecast/forecast_list_widget.dart
@@ -38,6 +38,7 @@ class _ForecastListWidgetState extends State<ForecastListWidget> {
               itemBuilder: (BuildContext context, int index) {
                 final AbstractForecast forecast =
                     forecastState.forecasts[index];
+
                 forecast.computeSlotInterference(timeSlotState);
 
                 return !forecast.hasPassed()


### PR DESCRIPTION
v3-beta version refuses to start because of the use of a `NativeAd` that does not exist anymore from the Java code Using `BannerAd` instead and temporarily removing `AdBannerWidget` instantiation from the app tree