### PR TITLE
fix(build): Beta version broken because of androidx.startup class

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,6 +65,8 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -25,3 +25,8 @@
 # Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
 -keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
 -keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
+# Fix for WorkManager crash in release mode (used by google_mobile_ads)
+# Github issue: https://github.com/googleads/googleads-mobile-flutter/issues/1444#issuecomment-4761480928
+-keep class androidx.work.impl.** { *; }
+-dontwarn androidx.work.impl.**


### PR DESCRIPTION
The beta version `3.0.1-beta` published on the PlayStore cannot start after download. Here the stach trace :
```
07-18 11:40:42.324 26427 26427 E AndroidRuntime: FATAL EXCEPTION: main
07-18 11:40:42.324 26427 26427 E AndroidRuntime: Process: fr.vareversat.chabo, PID: 26427
07-18 11:40:42.324 26427 26427 E AndroidRuntime: java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.app.ActivityThread.installProvider(ActivityThread.java:9191)
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.app.ActivityThread.installContentProviders(ActivityThread.java:8668)
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:8293)
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.app.ActivityThread.-$$Nest$mhandleBindApplication(ActivityThread.java:0)
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2761)
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.os.Handler.dispatchMessageImpl(Handler.java:142)
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:125)
07-18 11:40:42.324 26427 26427 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:296)
```

This is due to `google_mobile_ads` lib. Adding `proguard-rules.pro` should fix the issue.

Similar issue is reported here : https://github.com/flutter/flutter/issues/189508