### PR TITLE
feat: add notification permission snackbar with settings button

### DIFF
--- a/lib/bloc/theme/theme_bloc.dart
+++ b/lib/bloc/theme/theme_bloc.dart
@@ -89,9 +89,8 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
           themeData: _getCorrectThemeForSystem(),
           imagePath: _getCorrectImageData(ThemeStateStatus.system).path,
           imageCredits: _getCorrectImageData(ThemeStateStatus.system).credits,
-          imageCreditsLink: _getCorrectImageData(
-            ThemeStateStatus.system,
-          ).creditsLink,
+          imageCreditsLink: _getCorrectImageData(ThemeStateStatus.system)
+              .creditsLink,
         ),
       );
     } else {
@@ -102,9 +101,8 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
             themeData: theme.light(),
             imagePath: _getCorrectImageData(ThemeStateStatus.light).path,
             imageCredits: _getCorrectImageData(ThemeStateStatus.light).credits,
-            imageCreditsLink: _getCorrectImageData(
-              ThemeStateStatus.light,
-            ).creditsLink,
+            imageCreditsLink: _getCorrectImageData(ThemeStateStatus.light)
+                .creditsLink,
           ),
         );
       } else if (savedStatus == ThemeStateStatus.dark) {
@@ -114,9 +112,8 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
             themeData: theme.dark(),
             imagePath: _getCorrectImageData(ThemeStateStatus.dark).path,
             imageCredits: _getCorrectImageData(ThemeStateStatus.dark).credits,
-            imageCreditsLink: _getCorrectImageData(
-              ThemeStateStatus.dark,
-            ).creditsLink,
+            imageCreditsLink: _getCorrectImageData(ThemeStateStatus.dark)
+                .creditsLink,
           ),
         );
       } else if (savedStatus == ThemeStateStatus.system) {
@@ -126,9 +123,8 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
             themeData: _getCorrectThemeForSystem(),
             imagePath: _getCorrectImageData(ThemeStateStatus.system).path,
             imageCredits: _getCorrectImageData(ThemeStateStatus.system).credits,
-            imageCreditsLink: _getCorrectImageData(
-              ThemeStateStatus.system,
-            ).creditsLink,
+            imageCreditsLink: _getCorrectImageData(ThemeStateStatus.system)
+                .creditsLink,
           ),
         );
       }
@@ -147,9 +143,8 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
           themeData: theme.light(),
           imagePath: _getCorrectImageData(ThemeStateStatus.light).path,
           imageCredits: _getCorrectImageData(ThemeStateStatus.light).credits,
-          imageCreditsLink: _getCorrectImageData(
-            ThemeStateStatus.light,
-          ).creditsLink,
+          imageCreditsLink: _getCorrectImageData(ThemeStateStatus.light)
+              .creditsLink,
         ),
       );
     } else if (event.status == ThemeStateStatus.dark) {
@@ -159,9 +154,8 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
           themeData: theme.dark(),
           imagePath: _getCorrectImageData(ThemeStateStatus.dark).path,
           imageCredits: _getCorrectImageData(ThemeStateStatus.dark).credits,
-          imageCreditsLink: _getCorrectImageData(
-            ThemeStateStatus.dark,
-          ).creditsLink,
+          imageCreditsLink: _getCorrectImageData(ThemeStateStatus.dark)
+              .creditsLink,
         ),
       );
     } else if (event.status == ThemeStateStatus.system) {
@@ -171,9 +165,8 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
           themeData: _getCorrectThemeForSystem(),
           imagePath: _getCorrectImageData(ThemeStateStatus.system).path,
           imageCredits: _getCorrectImageData(ThemeStateStatus.system).credits,
-          imageCreditsLink: _getCorrectImageData(
-            ThemeStateStatus.system,
-          ).creditsLink,
+          imageCreditsLink: _getCorrectImageData(ThemeStateStatus.system)
+              .creditsLink,
         ),
       );
     }

--- a/lib/const.dart
+++ b/lib/const.dart
@@ -109,7 +109,9 @@ class Const {
   static const String notificationFavoriteSlotsValueKey =
       'NOTIFICATION_FAVORITE_SLOTS_SETTINGS_VALUE';
   static const String notificationFavoriteSlotsDaysValueKey =
-      'NOTIFICATION_FAVORITE_SLOTS_DAYS_SETTINGS_VALUE';
+      'NO********ION_FAVORITE_SLOTS_DAYS_SETTINGS_VALUE';
+  static const String notificationPermissionShownKey =
+      'NOTIFICATION_PERMISSION_SHOWN';
   static const String timeFormatKey = 'TIME_FORMAT';
 
   /// Notifications

--- a/lib/dialogs/days_of_the_week_dialog.dart
+++ b/lib/dialogs/days_of_the_week_dialog.dart
@@ -34,9 +34,8 @@ class DaysOfTheWeekDialog extends StatelessWidget {
                         borderRadius: BorderRadius.circular(12.0),
                         onChanged: (Day? value) {
                           if (value != null) {
-                            BlocProvider.of<NotificationBloc>(
-                              context,
-                            ).add(DayNotificationValueEvent(day: value));
+                            BlocProvider.of<NotificationBloc>(context)
+                                .add(DayNotificationValueEvent(day: value));
                           }
                         },
                         value: state.dayNotificationValue,

--- a/lib/extensions/boats_extension.dart
+++ b/lib/extensions/boats_extension.dart
@@ -22,12 +22,10 @@ extension BoatsExtension on List<Boat> {
     var finalString = '';
     for (var index = 0; index < length; index++) {
       finalString += this[index].isLeaving
-          ? AppLocalizations.of(
-              context,
-            )!.notificationTimeBoatDeparture(this[index].name)
-          : AppLocalizations.of(
-              context,
-            )!.notificationTimeBoatArrival(this[index].name);
+          ? AppLocalizations.of(context)!
+                .notificationTimeBoatDeparture(this[index].name)
+          : AppLocalizations.of(context)!
+                .notificationTimeBoatArrival(this[index].name);
       if (length - index > 2) {
         finalString += ', ';
       } else if (index + 1 != length) {
@@ -51,9 +49,9 @@ extension BoatsExtension on List<Boat> {
         boatCount += 1;
         finalTextSpan.add(
           TextSpan(
-            text: AppLocalizations.of(
-              context,
-            )!.the(this[index].name.startsWithVowel().toString()).capitalize(),
+            text: AppLocalizations.of(context)!
+                .the(this[index].name.startsWithVowel().toString())
+                .capitalize(),
           ),
         );
         finalTextSpan.add(this[index].toLocalizedTextSpan(context, true));

--- a/lib/extensions/color_scheme_extension.dart
+++ b/lib/extensions/color_scheme_extension.dart
@@ -28,4 +28,10 @@ extension ColorSchemeExtension on ColorScheme {
         ? const Color.fromRGBO(123, 31, 48, 1)
         : const Color.fromRGBO(167, 106, 117, 1);
   }
+
+  Color get errorColor {
+    return brightness == Brightness.light
+        ? const Color(0xFFB00020)
+        : const Color(0xFFCF6679);
+  }
 }

--- a/lib/extensions/date_time_extension.dart
+++ b/lib/extensions/date_time_extension.dart
@@ -54,9 +54,8 @@ extension DateTimeExtension on DateTime {
         TextSpan(text: stringDate),
         TextSpan(
           text: timeMarker,
-          style: Theme.of(
-            context,
-          ).textTheme.labelSmall?.copyWith(color: textStyle?.color),
+          style: Theme.of(context).textTheme.labelSmall
+              ?.copyWith(color: textStyle?.color),
         ),
       ],
       style: textStyle,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -198,6 +198,8 @@
   "favoriteSlotsInterferenceWarning": "This schedule interferes with one or more time slots",
   "favoriteTimeSlotEnabledWarning": "Attention, by activating this parameter you will only receive notifications when an event occurs during one of your time slots",
   "favoriteSlotsChooseDay": "Choose the days of the week",
+  "notificationsDisabledMessage": "Notifications are disabled. Please enable them to receive alerts about bridge closures.",
+  "enableNotificationsButton": "Enable notifications",
   "moonHarborStatus": "{count, plural, =1 {is} other {are}} currently docked in the 'Moon Harbor'",
   "@moonHarborStatus": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -198,6 +198,8 @@
   "favoriteSlotsInterferenceWarning": "Este horario interfiere con uno o màs intervalos de tiempo",
   "favoriteTimeSlotEnabledWarning": "Atención, al activar este paràmetro solo recibiràs notificaciones cuando ocurra un evento durante una de tus franjas horarias",
   "favoriteSlotsChooseDay": "Elegir los dìas de la semana",
+  "notificationsDisabledMessage": "Las notificaciones están desactivadas. Por favor, actívelas para recibir alertas sobre los cierres del puente.",
+  "enableNotificationsButton": "Activar notificaciones",
   "moonHarborStatus": "{count, plural, =1 {está actualmente amarrado} other {estàn actualmente amarrados}} en el 'Puerto de la Luna'",
   "@moonHarborStatus": {
     "placeholders": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -198,6 +198,8 @@
   "favoriteSlotsInterferenceWarning": "Cette prévision interfère avec un ou plusieurs créneaux",
   "favoriteTimeSlotEnabledWarning": "Attention, en activant ce paramètres vous allez uniquement recevoir les notifications lorsqu'un évèmenent se produit durant l'un de vos créneaux",
   "favoriteSlotsChooseDay": "Choisir les jours de la semaine",
+  "notificationsDisabledMessage": "Les notifications sont désactivées. Veuillez les activer pour recevoir des alertes concernant les fermetures du pont.",
+  "enableNotificationsButton": "Activer les notifications",
   "moonHarborStatus": "{count, plural, =1 {est actuellement amarré} other {sont actuellement amarrés}} au 'Port de la Lune'",
   "@moonHarborStatus": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -64,7 +64,7 @@ import 'app_localizations_fr.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -87,17 +87,17 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
     Locale('es'),
-    Locale('fr'),
+    Locale('fr')
   ];
 
   /// No description provided for @and.
@@ -495,19 +495,14 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'The Chaban bridge will close in {timeLeft} for {boat} 🚢. It will remains closed for {duration} 🌉'**
   String notificationDurationBoatMessage(
-    Object boat,
-    Object timeLeft,
-    Object duration,
-  );
+      Object boat, Object timeLeft, Object duration);
 
   /// No description provided for @notificationDurationMaintenanceMessage.
   ///
   /// In en, this message translates to:
   /// **'The Chaban Bridge will close in {timeLeft} for maintenance 🛠. It will remains closed for {duration} 🌉'**
   String notificationDurationMaintenanceMessage(
-    Object timeLeft,
-    Object duration,
-  );
+      Object timeLeft, Object duration);
 
   /// No description provided for @notificationDurationChannelName.
   ///
@@ -640,6 +635,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Choose the days of the week'**
   String get favoriteSlotsChooseDay;
+
+  /// No description provided for @notificationsDisabledMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications are disabled. Please enable them to receive alerts about bridge closures.'**
+  String get notificationsDisabledMessage;
+
+  /// No description provided for @enableNotificationsButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable notifications'**
+  String get enableNotificationsButton;
 
   /// No description provided for @moonHarborStatus.
   ///
@@ -809,9 +816,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -16,10 +16,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String the(String startWithVowel) {
-    String _temp0 = intl.Intl.selectLogic(startWithVowel, {
-      'true': 'the ',
-      'other': 'the ',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      startWithVowel,
+      {
+        'true': 'the ',
+        'other': 'the ',
+      },
+    );
     return '$_temp0';
   }
 
@@ -252,18 +255,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String notificationDurationBoatMessage(
-    Object boat,
-    Object timeLeft,
-    Object duration,
-  ) {
+      Object boat, Object timeLeft, Object duration) {
     return 'The Chaban bridge will close in $timeLeft for $boat 🚢. It will remains closed for $duration 🌉';
   }
 
   @override
   String notificationDurationMaintenanceMessage(
-    Object timeLeft,
-    Object duration,
-  ) {
+      Object timeLeft, Object duration) {
     return 'The Chaban Bridge will close in $timeLeft for maintenance 🛠. It will remains closed for $duration 🌉';
   }
 
@@ -275,10 +273,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String notificationTimeBoatMessage(
-    Object boat,
-    Object time,
-    Object duration,
-  ) {
+      Object boat, Object time, Object duration) {
     return 'The Chaban bridge will close tomorrow at $time for $boat 🚢. It will remains closed for $duration 🌉';
   }
 
@@ -302,16 +297,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String selectAboutDialog(String choice) {
-    String _temp0 = intl.Intl.selectLogic(choice, {
-      'source_code': 'Source code',
-      'privacy_policy': 'Privacy policy',
-      'yuhliet_instagram': 'Yuhliet\'s Instagram',
-      'city_of_bordeaux': 'City of Bordeaux',
-      'bordeaux_open_data': 'Bordeaux Open Data',
-      'licenses': 'Licenses',
-      'changelog': 'Changelog',
-      'other': 'Undefined',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      choice,
+      {
+        'source_code': 'Source code',
+        'privacy_policy': 'Privacy policy',
+        'yuhliet_instagram': 'Yuhliet\'s Instagram',
+        'city_of_bordeaux': 'City of Bordeaux',
+        'bordeaux_open_data': 'Bordeaux Open Data',
+        'licenses': 'Licenses',
+        'changelog': 'Changelog',
+        'other': 'Undefined',
+      },
+    );
     return '$_temp0';
   }
 
@@ -370,6 +368,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get favoriteSlotsChooseDay => 'Choose the days of the week';
+
+  @override
+  String get notificationsDisabledMessage =>
+      'Notifications are disabled. Please enable them to receive alerts about bridge closures.';
+
+  @override
+  String get enableNotificationsButton => 'Enable notifications';
 
   @override
   String moonHarborStatus(num count) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -16,10 +16,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String the(String startWithVowel) {
-    String _temp0 = intl.Intl.selectLogic(startWithVowel, {
-      'true': 'el ',
-      'other': 'el ',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      startWithVowel,
+      {
+        'true': 'el ',
+        'other': 'el ',
+      },
+    );
     return '$_temp0';
   }
 
@@ -254,18 +257,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String notificationDurationBoatMessage(
-    Object boat,
-    Object timeLeft,
-    Object duration,
-  ) {
+      Object boat, Object timeLeft, Object duration) {
     return 'El puente Chaban se cerrarà en $timeLeft para $boat 🚢. Permanecerà cerrado durante $duration 🌉';
   }
 
   @override
   String notificationDurationMaintenanceMessage(
-    Object timeLeft,
-    Object duration,
-  ) {
+      Object timeLeft, Object duration) {
     return 'El puente Chaban se cerrarà en $timeLeft para mantenimiento 🛠. Permanecerà cerrado durante $duration 🌉';
   }
 
@@ -277,10 +275,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String notificationTimeBoatMessage(
-    Object boat,
-    Object time,
-    Object duration,
-  ) {
+      Object boat, Object time, Object duration) {
     return 'El puente Chaban se cerrarà mañana a las $time para $boat 🚢. Permanecerà cerrado durante $duration 🌉';
   }
 
@@ -304,16 +299,19 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String selectAboutDialog(String choice) {
-    String _temp0 = intl.Intl.selectLogic(choice, {
-      'source_code': 'Código fuente',
-      'privacy_policy': 'Polìtica de privacidad',
-      'yuhliet_instagram': 'Instagram de Yuhliet',
-      'city_of_bordeaux': 'Ciudad de Burdeos',
-      'bordeaux_open_data': 'Bordeaux Open Data',
-      'licenses': 'Licencias',
-      'changelog': 'Registro de cambios',
-      'other': 'Indefinido',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      choice,
+      {
+        'source_code': 'Código fuente',
+        'privacy_policy': 'Polìtica de privacidad',
+        'yuhliet_instagram': 'Instagram de Yuhliet',
+        'city_of_bordeaux': 'Ciudad de Burdeos',
+        'bordeaux_open_data': 'Bordeaux Open Data',
+        'licenses': 'Licencias',
+        'changelog': 'Registro de cambios',
+        'other': 'Indefinido',
+      },
+    );
     return '$_temp0';
   }
 
@@ -373,6 +371,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get favoriteSlotsChooseDay => 'Elegir los dìas de la semana';
+
+  @override
+  String get notificationsDisabledMessage =>
+      'Las notificaciones están desactivadas. Por favor, actívelas para recibir alertas sobre los cierres del puente.';
+
+  @override
+  String get enableNotificationsButton => 'Activar notificaciones';
 
   @override
   String moonHarborStatus(num count) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -16,10 +16,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String the(String startWithVowel) {
-    String _temp0 = intl.Intl.selectLogic(startWithVowel, {
-      'true': 'l\'',
-      'other': 'le ',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      startWithVowel,
+      {
+        'true': 'l\'',
+        'other': 'le ',
+      },
+    );
     return '$_temp0';
   }
 
@@ -254,18 +257,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String notificationDurationBoatMessage(
-    Object boat,
-    Object timeLeft,
-    Object duration,
-  ) {
+      Object boat, Object timeLeft, Object duration) {
     return 'Le pont Chaban va se fermer dans $timeLeft pour $boat 🚢. Il restera fermé pendant $duration 🌉';
   }
 
   @override
   String notificationDurationMaintenanceMessage(
-    Object timeLeft,
-    Object duration,
-  ) {
+      Object timeLeft, Object duration) {
     return 'Le pont Chaban fermera dans $timeLeft pour maintenance 🛠. Il restera fermé pendant $duration 🌉';
   }
 
@@ -277,10 +275,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String notificationTimeBoatMessage(
-    Object boat,
-    Object time,
-    Object duration,
-  ) {
+      Object boat, Object time, Object duration) {
     return 'Le pont Chaban fermera demain à $time pour $boat 🚢. Il restera fermé pendant $duration 🌉';
   }
 
@@ -304,16 +299,19 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String selectAboutDialog(String choice) {
-    String _temp0 = intl.Intl.selectLogic(choice, {
-      'source_code': 'Code source',
-      'privacy_policy': 'Politique de confidentialité',
-      'yuhliet_instagram': 'Instagram de Yuhliet',
-      'city_of_bordeaux': 'Ville de Bordeaux',
-      'bordeaux_open_data': 'Bordeaux Open Data',
-      'licenses': 'Licences',
-      'changelog': 'Journal des modifications',
-      'other': 'Undefined',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      choice,
+      {
+        'source_code': 'Code source',
+        'privacy_policy': 'Politique de confidentialité',
+        'yuhliet_instagram': 'Instagram de Yuhliet',
+        'city_of_bordeaux': 'Ville de Bordeaux',
+        'bordeaux_open_data': 'Bordeaux Open Data',
+        'licenses': 'Licences',
+        'changelog': 'Journal des modifications',
+        'other': 'Undefined',
+      },
+    );
     return '$_temp0';
   }
 
@@ -374,6 +372,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get favoriteSlotsChooseDay => 'Choisir les jours de la semaine';
+
+  @override
+  String get notificationsDisabledMessage =>
+      'Les notifications sont désactivées. Veuillez les activer pour recevoir des alertes concernant les fermetures du pont.';
+
+  @override
+  String get enableNotificationsButton => 'Activer les notifications';
 
   @override
   String moonHarborStatus(num count) {

--- a/lib/models/abstract_forecast.dart
+++ b/lib/models/abstract_forecast.dart
@@ -69,9 +69,9 @@ abstract class AbstractForecast extends Equatable {
     final colorScheme = Theme.of(context).colorScheme;
     final timeFormat = context.read<TimeFormatCubit>().state.timeFormat;
 
-    var infoFromString = AppLocalizations.of(
-      context,
-    )!.dialogInformationContentThe.capitalize();
+    var infoFromString = AppLocalizations.of(context)!
+        .dialogInformationContentThe
+        .capitalize();
     var infoToString =
         ' ${AppLocalizations.of(context)!.dialogInformationContentFromStart} ';
     var infoToString2 =
@@ -81,9 +81,9 @@ abstract class AbstractForecast extends Equatable {
       Localizations.localeOf(context).languageCode,
     ).format(circulationReOpeningDate);
     if (isDuringTwoDays) {
-      infoFromString = AppLocalizations.of(
-        context,
-      )!.dialogInformationContentThe2.capitalize();
+      infoFromString = AppLocalizations.of(context)!
+          .dialogInformationContentThe2
+          .capitalize();
       infoToString = ' ';
       infoToString2 =
           ', ${AppLocalizations.of(context)!.dialogInformationContentFromEnd2} ${MaterialLocalizations.of(context).formatFullDate(circulationReOpeningDate)} ';
@@ -92,9 +92,8 @@ abstract class AbstractForecast extends Equatable {
     return [
       TextSpan(text: infoFromString),
       TextSpan(
-        text: MaterialLocalizations.of(
-          context,
-        ).formatFullDate(circulationClosingDate),
+        text: MaterialLocalizations.of(context)
+            .formatFullDate(circulationClosingDate),
         style: const TextStyle(fontWeight: FontWeight.bold),
       ),
       TextSpan(text: infoToString),

--- a/lib/models/boat_forecast.dart
+++ b/lib/models/boat_forecast.dart
@@ -181,12 +181,10 @@ class BoatForecast extends AbstractForecast {
                   children: [
                     Text(
                       boat.isLeaving
-                          ? AppLocalizations.of(
-                              context,
-                            )!.bottomSheetAdditionalInfo_boatArriving
-                          : AppLocalizations.of(
-                              context,
-                            )!.bottomSheetAdditionalInfo_boatLeaving,
+                          ? AppLocalizations.of(context)!
+                                .bottomSheetAdditionalInfo_boatArriving
+                          : AppLocalizations.of(context)!
+                                .bottomSheetAdditionalInfo_boatLeaving,
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
                         fontStyle: FontStyle.italic,
                         fontWeight: FontWeight.bold,
@@ -200,15 +198,13 @@ class BoatForecast extends AbstractForecast {
           }).toList(),
         ),
         Text(
-          AppLocalizations.of(
-            context,
-          )!.bottomSheetAdditionalInfo_boatCrossingTimeDisclaimer,
+          AppLocalizations.of(context)!
+              .bottomSheetAdditionalInfo_boatCrossingTimeDisclaimer,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.labelSmall?.copyWith(
             fontStyle: FontStyle.italic,
-            color: Theme.of(
-              context,
-            ).colorScheme.inverseSurface.withValues(alpha: .4),
+            color: Theme.of(context).colorScheme.inverseSurface
+                .withValues(alpha: .4),
           ),
         ),
       ],

--- a/lib/screens/about_screen/about_screen.dart
+++ b/lib/screens/about_screen/about_screen.dart
@@ -96,9 +96,9 @@ class AboutScreen extends StatelessWidget {
                               children: [
                                 Container(
                                   decoration: BoxDecoration(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.surfaceContainer,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceContainer,
                                     borderRadius: const BorderRadius.all(
                                       Radius.circular(
                                         CustomProperties.borderRadius,

--- a/lib/screens/about_screen/web_links_widget.dart
+++ b/lib/screens/about_screen/web_links_widget.dart
@@ -45,9 +45,8 @@ class _WebLinksWidget extends StatelessWidget {
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: 0),
                           child: Text(
-                            AppLocalizations.of(
-                              context,
-                            )!.selectAboutDialog(link.translationKey),
+                            AppLocalizations.of(context)!
+                                .selectAboutDialog(link.translationKey),
                           ),
                         ),
                         const Icon(Icons.outbond, size: 17),

--- a/lib/screens/error_screen.dart
+++ b/lib/screens/error_screen.dart
@@ -31,9 +31,8 @@ class _ErrorScreenState extends CustomWidgetState<ErrorScreen> {
                   Text(
                     AppLocalizations.of(context)!.errorScreenContentError,
                     textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      color: Theme.of(context).colorScheme.error,
-                    ),
+                    style: Theme.of(context).textTheme.titleLarge
+                        ?.copyWith(color: Theme.of(context).colorScheme.error),
                   ),
                   const SizedBox(height: 15),
                   Text(

--- a/lib/screens/forecast_screen.dart
+++ b/lib/screens/forecast_screen.dart
@@ -68,9 +68,9 @@ class _ForecastScreenState extends CustomWidgetState<ForecastScreen> {
                       /// And compute all notifications
                       BlocProvider.of<NotificationBloc>(context).add(
                         ComputeNotificationEvent(
-                          forecasts: BlocProvider.of<ForecastBloc>(
-                            context,
-                          ).state.forecasts,
+                          forecasts: BlocProvider.of<ForecastBloc>(context)
+                              .state
+                              .forecasts,
                           context: context,
                           timeSlotsState: BlocProvider.of<TimeSlotsBloc>(
                             context,
@@ -83,14 +83,14 @@ class _ForecastScreenState extends CustomWidgetState<ForecastScreen> {
                     listener: (context, state) {
                       /// If the TimeSlotsState changes and the timeSlotsEnabledForNotifications is enabled,
                       /// re-compute all notifications
-                      if (BlocProvider.of<NotificationBloc>(
-                        context,
-                      ).state.timeSlotsEnabledForNotifications) {
+                      if (BlocProvider.of<NotificationBloc>(context)
+                          .state
+                          .timeSlotsEnabledForNotifications) {
                         BlocProvider.of<NotificationBloc>(context).add(
                           ComputeNotificationEvent(
-                            forecasts: BlocProvider.of<ForecastBloc>(
-                              context,
-                            ).state.forecasts,
+                            forecasts: BlocProvider.of<ForecastBloc>(context)
+                                .state
+                                .forecasts,
                             context: context,
                             timeSlotsState: BlocProvider.of<TimeSlotsBloc>(
                               context,
@@ -105,9 +105,9 @@ class _ForecastScreenState extends CustomWidgetState<ForecastScreen> {
                       /// If the TimeFormatState changes, re compute all notifications
                       BlocProvider.of<NotificationBloc>(context).add(
                         ComputeNotificationEvent(
-                          forecasts: BlocProvider.of<ForecastBloc>(
-                            context,
-                          ).state.forecasts,
+                          forecasts: BlocProvider.of<ForecastBloc>(context)
+                              .state
+                              .forecasts,
                           context: context,
                           timeSlotsState: BlocProvider.of<TimeSlotsBloc>(
                             context,

--- a/lib/screens/notification_screen/custom_list_tile_widget.dart
+++ b/lib/screens/notification_screen/custom_list_tile_widget.dart
@@ -44,9 +44,8 @@ class _CustomListTileWidget extends StatelessWidget {
                 flex: 10,
                 child: Text(
                   title,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.titleLarge?.copyWith(fontSize: 19),
+                  style: Theme.of(context).textTheme.titleLarge
+                      ?.copyWith(fontSize: 19),
                   overflow: TextOverflow.fade,
                 ),
               ),
@@ -75,9 +74,9 @@ class _CustomListTileWidget extends StatelessWidget {
                   child: constrainedBySlots && enabled
                       ? CircleAvatar(
                           radius: 5,
-                          backgroundColor: Theme.of(
-                            context,
-                          ).colorScheme.warningColor,
+                          backgroundColor: Theme.of(context)
+                              .colorScheme
+                              .warningColor,
                           child: Container(),
                         )
                       : const SizedBox(),

--- a/lib/screens/notification_screen/favorite_slots_day_picker_dialog.dart
+++ b/lib/screens/notification_screen/favorite_slots_day_picker_dialog.dart
@@ -29,9 +29,9 @@ class FavoriteSlotsDayPickerDialog extends StatelessWidget {
                 ),
                 selected: state.days.contains(day),
                 shape: const StadiumBorder(side: BorderSide()),
-                onSelected: (bool selected) => BlocProvider.of<TimeSlotsBloc>(
-                  context,
-                ).add(DaysChanged(day: day, isSelected: selected)),
+                onSelected: (bool selected) =>
+                    BlocProvider.of<TimeSlotsBloc>(context)
+                        .add(DaysChanged(day: day, isSelected: selected)),
               );
             }).toList(),
           );

--- a/lib/screens/notification_screen/favorite_slots_widget.dart
+++ b/lib/screens/notification_screen/favorite_slots_widget.dart
@@ -59,26 +59,24 @@ class _FavoriteSlotsWidgetState extends State<_FavoriteSlotsWidget>
             children: [
               _CustomListTileWidget(
                 onChanged: (bool value) => {
-                  BlocProvider.of<NotificationBloc>(
-                    context,
-                  ).add(EnabledTimeSlotEvent(enabled: value)),
+                  BlocProvider.of<NotificationBloc>(context)
+                      .add(EnabledTimeSlotEvent(enabled: value)),
                   if (value)
                     {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           duration: const Duration(seconds: 7),
                           showCloseIcon: true,
-                          backgroundColor: Theme.of(
-                            context,
-                          ).colorScheme.warningColor,
+                          backgroundColor: Theme.of(context)
+                              .colorScheme
+                              .warningColor,
                           content: Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Flexible(
                                 child: Text(
-                                  AppLocalizations.of(
-                                    context,
-                                  )!.favoriteTimeSlotEnabledWarning,
+                                  AppLocalizations.of(context)!
+                                      .favoriteTimeSlotEnabledWarning,
                                   style: const TextStyle(
                                     fontWeight: FontWeight.bold,
                                   ),
@@ -98,9 +96,8 @@ class _FavoriteSlotsWidgetState extends State<_FavoriteSlotsWidget>
                 },
                 enabled: widget.timeSlotsEnabledForNotifications,
                 title: AppLocalizations.of(context)!.favoriteSlots,
-                subtitle: AppLocalizations.of(
-                  context,
-                )!.favoriteSlotsDescription,
+                subtitle: AppLocalizations.of(context)!
+                    .favoriteSlotsDescription,
                 leadingIcon: Icons.warning_rounded,
                 iconColor: Theme.of(context).colorScheme.warningColor,
                 constrainedBySlots: false,

--- a/lib/screens/notification_screen/notification_screen.dart
+++ b/lib/screens/notification_screen/notification_screen.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import 'package:flutter/scheduler.dart';
+
 import 'package:chabo_app/bloc/notification/notification_bloc.dart';
 import 'package:chabo_app/bloc/time_slots/time_slots_bloc.dart';
 import 'package:chabo_app/cubits/time_format_cubit.dart';
@@ -37,6 +39,53 @@ class _NotificationScreenState extends CustomWidgetState<NotificationScreen> {
   _NotificationScreenState() : super(screenName: 'notification-screen');
 
   @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _checkNotificationsEnabled();
+    });
+  }
+
+  Future<void> _checkNotificationsEnabled() async {
+    if (!mounted) return;
+    final storageService = BlocProvider.of<NotificationBloc>(context).storageService;
+    final hasShown = storageService.sharedPreferences.getBool(Const.notificationPermissionShownKey) ?? false;
+    if (hasShown) return;
+    
+    final notificationService = BlocProvider.of<NotificationBloc>(context)
+        .notificationService;
+    final areEnabled = await notificationService.areNotificationsEnabled();
+    if (!areEnabled && mounted) {
+      await storageService.saveBool(Const.notificationPermissionShownKey, true);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          duration: const Duration(seconds: 10),
+          showCloseIcon: true,
+          backgroundColor: Theme.of(context).colorScheme.errorColor,
+          content: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Flexible(
+                child: Text(
+                  AppLocalizations.of(context)!.notificationsDisabledMessage,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
+          action: SnackBarAction(
+            label: AppLocalizations.of(context)!.enableNotificationsButton,
+            textColor: Colors.white,
+            onPressed: (() async {
+              await notificationService.requestPermissions();
+            }),
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: ChaboAppBar(),
@@ -66,12 +115,10 @@ class _NotificationScreenState extends CustomWidgetState<NotificationScreen> {
                             context,
                           ).add(OpeningNotificationStateEvent(enabled: value)),
                       enabled: notificationState.openingNotificationEnabled,
-                      title: AppLocalizations.of(
-                        context,
-                      )!.openingNotificationTitle,
-                      subtitle: AppLocalizations.of(
-                        context,
-                      )!.openingNotificationExplanation,
+                      title: AppLocalizations.of(context)!
+                          .openingNotificationTitle,
+                      subtitle: AppLocalizations.of(context)!
+                          .openingNotificationExplanation,
                       leadingIcon: Icons.check_circle,
                       iconColor: Colors.green,
                       constrainedBySlots:
@@ -83,12 +130,10 @@ class _NotificationScreenState extends CustomWidgetState<NotificationScreen> {
                             context,
                           ).add(ClosingNotificationStateEvent(enabled: value)),
                       enabled: notificationState.closingNotificationEnabled,
-                      title: AppLocalizations.of(
-                        context,
-                      )!.closingNotificationTitle,
-                      subtitle: AppLocalizations.of(
-                        context,
-                      )!.closingNotificationExplanation,
+                      title: AppLocalizations.of(context)!
+                          .closingNotificationTitle,
+                      subtitle: AppLocalizations.of(context)!
+                          .closingNotificationExplanation,
                       leadingIcon: Icons.block_rounded,
                       iconColor: Colors.red,
                       constrainedBySlots:
@@ -104,9 +149,8 @@ class _NotificationScreenState extends CustomWidgetState<NotificationScreen> {
                               .durationToTimeOfDay(),
                           builder: (BuildContext context, Widget? child) {
                             return MediaQuery(
-                              data: MediaQuery.of(
-                                context,
-                              ).copyWith(alwaysUse24HourFormat: true),
+                              data: MediaQuery.of(context)
+                                  .copyWith(alwaysUse24HourFormat: true),
                               child: child!,
                             );
                           },
@@ -115,16 +159,15 @@ class _NotificationScreenState extends CustomWidgetState<NotificationScreen> {
                             if (value != null)
                               {
                                 if (context.mounted)
-                                  BlocProvider.of<NotificationBloc>(
-                                    context,
-                                  ).add(
-                                    DurationNotificationValueEvent(
-                                      duration: Duration(
-                                        hours: value.hour,
-                                        minutes: value.minute,
+                                  BlocProvider.of<NotificationBloc>(context)
+                                      .add(
+                                        DurationNotificationValueEvent(
+                                          duration: Duration(
+                                            hours: value.hour,
+                                            minutes: value.minute,
+                                          ),
+                                        ),
                                       ),
-                                    ),
-                                  ),
                               },
                           },
                         );
@@ -169,24 +212,22 @@ class _NotificationScreenState extends CustomWidgetState<NotificationScreen> {
                             if (value != null)
                               {
                                 if (context.mounted)
-                                  BlocProvider.of<NotificationBloc>(
-                                    context,
-                                  ).add(
-                                    TimeNotificationValueEvent(
-                                      time: TimeOfDay(
-                                        hour: value.hour,
-                                        minute: value.minute,
+                                  BlocProvider.of<NotificationBloc>(context)
+                                      .add(
+                                        TimeNotificationValueEvent(
+                                          time: TimeOfDay(
+                                            hour: value.hour,
+                                            minute: value.minute,
+                                          ),
+                                        ),
                                       ),
-                                    ),
-                                  ),
                               },
                           },
                         );
                       },
                       onChanged: (bool value) =>
-                          BlocProvider.of<NotificationBloc>(
-                            context,
-                          ).add(TimeNotificationStateEvent(enabled: value)),
+                          BlocProvider.of<NotificationBloc>(context)
+                              .add(TimeNotificationStateEvent(enabled: value)),
                       enabled: notificationState.timeNotificationEnabled,
                       title: AppLocalizations.of(context)!
                           .timeNotificationTitle(
@@ -242,9 +283,8 @@ class _NotificationScreenState extends CustomWidgetState<NotificationScreen> {
                           ),
                       leadingIcon: Icons.calendar_month_outlined,
                       onChanged: (bool value) =>
-                          BlocProvider.of<NotificationBloc>(
-                            context,
-                          ).add(DayNotificationStateEvent(enabled: value)),
+                          BlocProvider.of<NotificationBloc>(context)
+                              .add(DayNotificationStateEvent(enabled: value)),
                       constrainedBySlots:
                           notificationState.timeSlotsEnabledForNotifications,
                     ),

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -82,9 +82,9 @@ class SettingScreen extends StatelessWidget {
                                     : colorScheme.onSurface,
                               );
                             },
-                            onChanged: (value) => BlocProvider.of<ThemeBloc>(
-                              context,
-                            ).add(ThemeChanged(status: value)),
+                            onChanged: (value) =>
+                                BlocProvider.of<ThemeBloc>(context)
+                                    .add(ThemeChanged(status: value)),
                           ),
                           AnimatedSwitcher(
                             duration: const Duration(

--- a/lib/screens/status_screen/status_screen.dart
+++ b/lib/screens/status_screen/status_screen.dart
@@ -40,9 +40,8 @@ class StatusScreenState extends CustomWidgetState<StatusScreen> {
     SchedulerBinding.instance.addPostFrameCallback((_) {
       Timer.periodic(const Duration(seconds: 1), (Timer t) {
         if (mounted) {
-          BlocProvider.of<StatusBloc>(
-            context,
-          ).add(StatusRefresh(context: context));
+          BlocProvider.of<StatusBloc>(context)
+              .add(StatusRefresh(context: context));
         } else {
           t.cancel();
         }

--- a/lib/service/notification_service.dart
+++ b/lib/service/notification_service.dart
@@ -104,6 +104,10 @@ class NotificationService {
     return false;
   }
 
+  Future<bool> requestPermissions() async {
+    return await _requestPermissions();
+  }
+
   Future<bool> areNotificationsEnabled() async {
     if (Platform.isAndroid) {
       final AndroidFlutterLocalNotificationsPlugin? androidImplementation =
@@ -129,8 +133,9 @@ class NotificationService {
     await localNotifications.cancelAll();
     List<DateTime> weekSeparatedForecast = [];
 
-    /// Make sure that the user enable the notification
-    if (await _requestPermissions()) {
+    /// Check if notifications are enabled before proceeding
+    final areEnabled = await areNotificationsEnabled();
+    if (areEnabled) {
       for (final forecast in forecasts) {
         /// Compute the slot time linked to a forecast before starting the notification computation
         forecast.computeSlotInterference(timeSlotsState);

--- a/lib/widgets/bottom_sheets/forecast_information_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/forecast_information_bottom_sheet.dart
@@ -95,9 +95,8 @@ class _ForecastInformationBottomSheetState
                 date: widget.forecast.circulationClosingDate
                     .toLocalizedTextSpan(
                       context,
-                      Theme.of(context).textTheme.headlineLarge?.copyWith(
-                        color: colorScheme.error,
-                      ),
+                      Theme.of(context).textTheme.headlineLarge
+                          ?.copyWith(color: colorScheme.error),
                     ),
                 text: appLocalization!.circulationClosing.toUpperCase(),
               ),
@@ -107,9 +106,8 @@ class _ForecastInformationBottomSheetState
                 date: widget.forecast.circulationReOpeningDate
                     .toLocalizedTextSpan(
                       context,
-                      Theme.of(context).textTheme.headlineLarge?.copyWith(
-                        color: colorScheme.primary,
-                      ),
+                      Theme.of(context).textTheme.headlineLarge
+                          ?.copyWith(color: colorScheme.primary),
                     ),
                 text: appLocalization.circulationReOpening.toUpperCase(),
               ),

--- a/lib/widgets/chabo_app_bar/chabo_app_bar.dart
+++ b/lib/widgets/chabo_app_bar/chabo_app_bar.dart
@@ -48,9 +48,8 @@ class ChaboAppBarState extends State<ChaboAppBar> {
         children: [
           Text(
             Const.appName,
-            style: Theme.of(
-              context,
-            ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            style: Theme.of(context).textTheme.titleLarge
+                ?.copyWith(fontWeight: FontWeight.bold),
           ),
           widget.displayStatus
               ? Padding(

--- a/lib/widgets/forecast/forecast_list_widget.dart
+++ b/lib/widgets/forecast/forecast_list_widget.dart
@@ -32,9 +32,8 @@ class _ForecastListWidgetState extends State<ForecastListWidget> {
             return ListView.separated(
               scrollCacheExtent: ScrollCacheExtent.pixels(5000),
               shrinkWrap: true,
-              padding: const EdgeInsets.symmetric(
-                horizontal: 5,
-              ).copyWith(bottom: 150),
+              padding: const EdgeInsets.symmetric(horizontal: 5)
+                  .copyWith(bottom: 150),
               itemBuilder: (BuildContext context, int index) {
                 final AbstractForecast forecast =
                     forecastState.forecasts[index];
@@ -93,9 +92,8 @@ class _MonthWidget extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 6.0),
           child: Text(
-            DateFormat.yMMMM(
-              Localizations.localeOf(context).languageCode,
-            ).format(forecast.circulationClosingDate),
+            DateFormat.yMMMM(Localizations.localeOf(context).languageCode)
+                .format(forecast.circulationClosingDate),
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ),

--- a/lib/widgets/forecast/forecast_widget.dart
+++ b/lib/widgets/forecast/forecast_widget.dart
@@ -56,9 +56,9 @@ class ForecastWidget extends StatelessWidget {
                     )
                   : BorderSide(
                       width: 2,
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.surfaceContainerHighest,
+                      color: Theme.of(context)
+                          .colorScheme
+                          .surfaceContainerHighest,
                     ),
             ),
           ),
@@ -96,9 +96,8 @@ class ForecastWidget extends StatelessWidget {
                   Text(
                     forecast.circulationClosingDate.day ==
                             forecast.circulationReOpeningDate.day
-                        ? DateFormat.MMMMEEEEd(
-                            local,
-                          ).format(forecast.circulationClosingDate)
+                        ? DateFormat.MMMMEEEEd(local)
+                              .format(forecast.circulationClosingDate)
                         : '${DateFormat.MMMEd(local).format(forecast.circulationClosingDate)} / '
                               '${DateFormat.MMMEd(local).format(forecast.circulationReOpeningDate)}',
                     style: Theme.of(context).textTheme.headlineSmall,
@@ -113,12 +112,13 @@ class ForecastWidget extends StatelessWidget {
                             text: forecast.circulationClosingDate
                                 .toLocalizedTextSpan(
                                   context,
-                                  Theme.of(
-                                    context,
-                                  ).textTheme.headlineSmall?.copyWith(
-                                    color: Theme.of(context).colorScheme.error,
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                                  Theme.of(context).textTheme.headlineSmall
+                                      ?.copyWith(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .error,
+                                        fontWeight: FontWeight.bold,
+                                      ),
                                 ),
                           ),
                           SizedBox(width: 10),
@@ -126,13 +126,12 @@ class ForecastWidget extends StatelessWidget {
                             text: forecast.circulationReOpeningDate
                                 .toLocalizedTextSpan(
                                   context,
-                                  Theme.of(
-                                    context,
-                                  ).textTheme.bodyLarge?.copyWith(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.onSurface,
-                                  ),
+                                  Theme.of(context).textTheme.bodyLarge
+                                      ?.copyWith(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurface,
+                                      ),
                                 ),
                           ),
                         ],

--- a/lib/widgets/forecast/no_more_forecasts_widget.dart
+++ b/lib/widgets/forecast/no_more_forecasts_widget.dart
@@ -17,9 +17,8 @@ class NoMoreForecastsWidget extends StatelessWidget {
           Center(
             child: Text(
               AppLocalizations.of(context)!.noMoreForecastsTitle,
-              style: Theme.of(
-                context,
-              ).textTheme.titleLarge!.copyWith(fontWeight: FontWeight.bold),
+              style: Theme.of(context).textTheme.titleLarge!
+                  .copyWith(fontWeight: FontWeight.bold),
             ),
           ),
           Padding(

--- a/lib/widgets/progress_indicator/custom_circular_progress_indicator.dart
+++ b/lib/widgets/progress_indicator/custom_circular_progress_indicator.dart
@@ -21,9 +21,8 @@ class CustomCircularProgressIndicator extends StatelessWidget {
             padding: const EdgeInsets.all(8.0),
             child: Text(
               message,
-              style: Theme.of(
-                context,
-              ).textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.bold),
+              style: Theme.of(context).textTheme.bodyMedium!
+                  .copyWith(fontWeight: FontWeight.bold),
             ),
           ),
         ],

--- a/lib/widgets/progress_indicator/progress_indicator_widget.dart
+++ b/lib/widgets/progress_indicator/progress_indicator_widget.dart
@@ -25,18 +25,15 @@ class ProgressIndicatorWidget extends StatelessWidget {
           },
           child: Text(
             statusState.timeMessagePrefix,
-            style: Theme.of(
-              context,
-            ).textTheme.labelLarge!.copyWith(fontSize: 18),
+            style: Theme.of(context).textTheme.labelLarge!
+                .copyWith(fontSize: 18),
           ),
         ),
         !statusState.durationUntilNextEvent.isNegative
             ? Text(
                 statusState.durationUntilNextEvent.durationToString(context),
-                style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                  fontSize: 16,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: Theme.of(context).textTheme.titleMedium!
+                    .copyWith(fontSize: 16, fontWeight: FontWeight.bold),
               )
             : const SizedBox.shrink(),
         statusState.completionPercentage != -1

--- a/lib/widgets/time_slot_widget.dart
+++ b/lib/widgets/time_slot_widget.dart
@@ -40,9 +40,8 @@ class TimeSlotWidget extends StatelessWidget {
             if (value != null)
               {
                 if (context.mounted)
-                  BlocProvider.of<NotificationBloc>(
-                    context,
-                  ).add(DayNotificationValueEvent(day: value)),
+                  BlocProvider.of<NotificationBloc>(context)
+                      .add(DayNotificationValueEvent(day: value)),
               },
           },
         );
@@ -56,9 +55,8 @@ class TimeSlotWidget extends StatelessWidget {
                 Text(
                   timeSlot.name != ''
                       ? timeSlot.name
-                      : AppLocalizations.of(
-                          context,
-                        )!.favoriteTimeSlotDefaultName(index + 1),
+                      : AppLocalizations.of(context)!
+                            .favoriteTimeSlotDefaultName(index + 1),
                 ),
                 Text(
                   '${timeSlot.from.toFormattedString(timeFormatState.timeFormat)} - ${timeSlot.to.toFormattedString(timeFormatState.timeFormat)}',


### PR DESCRIPTION
- Add errorColor to ColorSchemeExtension for red background (light/dark theme support)
- Add translation strings for notification disabled message and enable button
- Fix computeNotifications to use areNotificationsEnabled instead of _requestPermissions
- Add public requestPermissions method for external use
- Show snackbar in notification screen when notifications are disabled with button to enable them

Closes #